### PR TITLE
Increase minimum required CMake version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 set(CMAKE_CXX_STANDARD 17)
 
 project(libnut)


### PR DESCRIPTION
Fixes #35

Alternatively, one could work around the use of `add_compile_definitions`. Increasing the minimum required version just seemed easier.