### PR TITLE
Add arch flag for universal mac builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "cmake-js clean",
     "patch": "node ./patch-packagename.js",
     "build:debug": "cmake-js rebuild --debug",
-    "build:release": "cmake-js rebuild",
+    "build:release": "cmake-js rebuild --CDCMAKE_OSX_ARCHITECTURES=\"arm64;x86_64\"",
     "prepublishOnly": "npm run build:release",
     "publish:next": "npm publish --tag next"
   },


### PR DESCRIPTION
I investigated a bit and looks like the only way to make it work here is by the CLI flag.
I tried adding it to CMakeLists.txt but it never worked despite different suggestions online (seems to be a known issue).

This flag is ignored on non-OSX environments and targets so it's safe in that regard.

Let me know if this is okay.

Fixes #49 