### PR TITLE
Throw error on null bitmap to prevent crash

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -758,6 +758,10 @@ Napi::Object _captureScreen(const Napi::CallbackInfo &info)
 	}
 
 	MMBitmapRef bitmap = copyMMBitmapFromDisplayInRect(MMRectMake(x, y, w, h));
+	
+	if (bitmap == NULL) {
+		throw Napi::Error::New(env, "Error: Failed to capture screen");
+	}
 
 	uint32_t bufferSize = bitmap->bytewidth * bitmap->height;
 	Napi::Buffer<char> buffer = Napi::Buffer<char>::New(env, (char *)bitmap->imageBuffer, bufferSize, finalizer);


### PR DESCRIPTION
I've been exploring using nut.js (and more recently the libnut library directly) to control a headless Windows machine monitored through RDP (Using the [official Remote Desktop app](https://www.microsoft.com/en-us/p/microsoft-remote-desktop/9wzdncrfj3ps?activetab=pivot:overviewtab)).

The setup generally worked fine, but I noticed the node process ends up consistently crashing as soon as I disconnect the RDP session. 

Dug into it a bit this weekend and found that the crash was due to [this null returning branch in `copyMMBitmapFromDisplayInRect`](https://github.com/nut-tree/libnut/blob/develop/src/win32/screengrab.c#L50) being unhandled downstream.

This PR handles the null case by throwing an exception so it can be handled in userland appropriately (in my case a simple retry after some delay) instead of crashing the entire program.

It's been a while since I wrote any C, so please let me know if there's any other cleanup steps necessary before throwing the exception that I might have missed. Thanks!