### PR TITLE
Remove microsleep after tapping or toggling keyboard

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -483,7 +483,6 @@ Napi::Number _keyTap(const Napi::CallbackInfo &info)
 		break;
 	default:
 		tapKeyCode(key, flags);
-		microsleep(keyboardDelay);
 	}
 
 	return Napi::Number::New(env, 1);
@@ -552,7 +551,6 @@ Napi::Number _keyToggle(const Napi::CallbackInfo &info)
 		break;
 	default:
 		toggleKeyCode(key, down, flags);
-		microsleep(keyboardDelay);
 	}
 
 	return Napi::Number::New(env, 1);


### PR DESCRIPTION
What:
-
- Remove micro sleep after keyboard taps and toggles


Why:
-
- [Issue 220](https://github.com/nut-tree/nut.js/issues/220)
- Keyboard delay is not behaving in an expected way. 
- The delay is unexpectedly 300ms for pressKey() and type() even when setting the keyboard delay to be less than 300ms.
- Nut.js `type() {@link String}` is much faster than `type() {@link Key}` IE  `type('backspace')` vs `type(Key.Backspace)`
- It is therefor faster to execute keyboard.type('backspace') than it is to press the backspace key

Miscellaneous notes:
-
- ~~NOT TESTED~~ 
- Potentially related robot js issue: [530](https://github.com/octalmage/robotjs/issues/530#issuecomment-756057632)


Update:
-
- Tested on a forked branch, confirmed the problem stems from this code and can be resolved with this change. I'm not sure if there are repercussions for apps that utilize the keyboard delay. 
