### PR TITLE
moveMouse refactor to use sendInput on Windows (#26)

### DIFF
--- a/src/win32/mouse.c
+++ b/src/win32/mouse.c
@@ -1,4 +1,5 @@
 #include "../mouse.h"
+#include "../screen.h"
 #include "../microsleep.h"
 
 #include <math.h> /* For floor() */


### PR DESCRIPTION
Hi,

This PR should nicely refactor the moveMouse method
Ref: https://github.com/nut-tree/libnut/issues/26

I believe everything here is inline with the Microsoft documentation and guidelines here
https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-mouseinput

There might still be some flags worth exploring and dwExtraInfo but I am not too sure

Not sure if you want the helper methods for converting the points to absolute coords to live within mouse.c