### PR TITLE
Bugfix for lost co-ordinate precision

### DIFF
--- a/src/win32/mouse.c
+++ b/src/win32/mouse.c
@@ -32,7 +32,7 @@
 
 MMPoint CalculateAbsoluteCoordinates(MMPoint point) {
 	MMSize displaySize = getMainDisplaySize();
-	return MMPointMake((point.x / displaySize.width) * ABSOLUTE_COORD_CONST,  (point.y / displaySize.height) * ABSOLUTE_COORD_CONST);
+	return MMPointMake(((float) point.x / displaySize.width) * ABSOLUTE_COORD_CONST,  ((float) point.y / displaySize.height) * ABSOLUTE_COORD_CONST);
 }
 
 /**


### PR DESCRIPTION
Hi,

There is a bug with my previous PR with some lost precision because of an implicit cast. Causes weird behaviour with very small values for the X/Y Point