### PR TITLE
Remove scan code KEYUP block

### DIFF
--- a/src/win32/keypress.c
+++ b/src/win32/keypress.c
@@ -53,12 +53,6 @@ void win32KeyEvent(int key, MMKeyFlags flags)
 	}
 	}
 
-	/* Set the scan code for keyup */
-	if (flags & KEYEVENTF_KEYUP)
-	{
-		scan |= 0x80;
-	}
-
 	INPUT keyboardInput;
 	keyboardInput.type = INPUT_KEYBOARD;
 	keyboardInput.ki.wScan = (WORD)scan;


### PR DESCRIPTION
Based on my own testing and the following issue: https://github.com/octalmage/robotjs/issues/252

I think we are better off removing this block. It does not seem to serve any functional purpose and has caused issues for users of Robot.js and also reports from users of Nut.js