### PR TITLE
Adjust on getScaleRect

### DIFF
--- a/src/win32/screengrab.c
+++ b/src/win32/screengrab.c
@@ -20,7 +20,7 @@ MMRect getScaledRect(MMRect input)
 
 	// return MMRectMake(input.origin.x, input.origin.y, input.size.width / scaleX, input.size.height / scaleY);
 
-	auto activeWindow = GetActiveWindow();
+	auto activeWindow = GetForegroundWindow();
 	HMONITOR monitor = MonitorFromWindow(activeWindow, MONITOR_DEFAULTTONEAREST);
 
 	MONITORINFOEX monitorInfoEx;


### PR DESCRIPTION
Adjust on getScaleRect to work on previous versions of windows, the previous version of this function was using a Windows 10 function to set dpi awareness, I've tested on Windows 10, 11 and 7 and works well.