### PR TITLE
Fix capture region x,y offset when DPI scaling on Windows

### DIFF
--- a/src/win32/screengrab.c
+++ b/src/win32/screengrab.c
@@ -16,7 +16,12 @@ MMRect getScaledRect(MMRect input)
 	double scaleX = (double)(desktopWidth / (double)scaledDesktopWidth);
 	double scaleY = (double)(desktopHeight / (double)scaledDesktopHeight);
 
-	return MMRectMake(input.origin.x, input.origin.y, input.size.width / scaleX, input.size.height / scaleY);
+	return MMRectMake(
+		input.origin.x / scaleX, 
+		input.origin.y / scaleY, 
+		input.size.width / scaleX, 
+		input.size.height / scaleY
+	);
 }
 
 MMBitmapRef copyMMBitmapFromDisplayInRect(MMRect rect)


### PR DESCRIPTION
Same as with the scaled width and height with DPI scaling, we need to take it into account for x and y position.